### PR TITLE
Update syntax highlighting on language change

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,13 +33,13 @@
         <div class="row">
             <div class="col-sm">
                 <select id="langSelect">
-                    <option value="seeds/bash_seed.sh">Bash</option>
-                    <option value="seeds/groovy_seed.groovy">Groovy</option>
-                    <option value="seeds/javascript_seed.js">JavaScript</option>
-                    <option value="seeds/php_seed.php">PHP</option>
-                    <option value="seeds/python_seed.py">Python</option>
-                    <option value="seeds/ruby_seed.rb">Ruby</option>
-                    <option value="seeds/scala_seed.scala">Scala</option>
+                    <option value="bash">Bash</option>
+                    <option value="groovy">Groovy</option>
+                    <option value="javascript">JavaScript</option>
+                    <option value="php">PHP</option>
+                    <option value="python">Python</option>
+                    <option value="ruby">Ruby</option>
+                    <option value="scala">Scala</option>
                 </select>
             </div>
             <div class="col-sm text-right">
@@ -50,7 +50,7 @@
 
         <div class="row">
             <div class="col-sm">
-                <pre><code id="seedScript" class="language-bash"></code></pre>
+                <pre><code id="seedScript" class="hljs"></code></pre>
             </div>
         </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -1,20 +1,66 @@
+let seedElement;
+const LANGUAGES = {
+  'bash': {
+    file: 'seeds/bash_seed.sh',
+    class: 'bash'  
+  },
+  'groovy': {
+    file: 'seeds/groovy_seed.groovy',
+    class: 'groovy'  
+  },
+  'javascript': {
+    file: 'seeds/javascript_seed.js',
+    class: 'javascript'  
+  },
+  'php': {
+    file: 'seeds/php_seed.php',
+    class: 'php'  
+  },
+  'python': {
+    file: 'seeds/python_seed.py',
+    class: 'python'  
+  },
+  'ruby': {
+    file: 'seeds/ruby_seed.rb',
+    class: 'ruby'  
+  },
+  'scala': {
+    file: 'seeds/scala_seed.scala',
+    class: 'scala'
+  }
+}
+
+function getFileForLanguage(language) {
+  return LANGUAGES[language].file;
+}
+
+function getClassForLanguage(language) {
+  return LANGUAGES[language].class;
+}
+
 function onReady() {
+  seedElement = document.getElementById("seedScript");
+
   const langSelect = document.getElementById("langSelect");
   langSelect.onchange = function() {
     onChange(langSelect.value);
   };
 
-  onChange("seeds/bash_seed.sh");
+  onChange("bash");
 }
 
-function onChange(seed) {
-  fetch(seed)
+function onChange(language) {
+  let languageFile = getFileForLanguage(language);
+  let languageClass = getClassForLanguage(language);
+  
+  fetch(languageFile)
     .then(function(response) {
       response.text().then(function(text) {
-        var seedElement = document.getElementById("seedScript");
         seedElement.textContent = text;
-        document.getElementById("downloadButton").href = seed;
+        seedElement.className = `${languageClass} hljs`;
         hljs.highlightBlock(seedElement);
+
+        document.getElementById("downloadButton").href = languageFile;
       });
     })
     .catch(function(error) {


### PR DESCRIPTION
Currently when you switch between seeds, highlight.js continues to attempt to highlight code as if it were bash. This PR gets the syntax highlighting updating when the seed file changes.

The refactor of the storage mechanism for seed file locations isn't something I'm in love with, but it seemed to be a better route than attempting to parse the seed file name to determine the language name. I'm open to other approaches. 