### PR TITLE
Add AWK seed script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /root
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get install -y curl groovy nodejs openjdk-8-jre-headless php python ruby
+    apt-get install -y curl groovy nodejs openjdk-8-jre-headless php python ruby gawk
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 # Install Scala from source.

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
         <div class="row">
             <div class="col-sm">
                 <select id="langSelect">
+                    <option value="seeds/awk_seed.awk">AWK</option>
                     <option value="seeds/bash_seed.sh">Bash</option>
                     <option value="seeds/groovy_seed.groovy">Groovy</option>
                     <option value="seeds/javascript_seed.js">JavaScript</option>

--- a/seeds/awk_seed.awk
+++ b/seeds/awk_seed.awk
@@ -1,0 +1,23 @@
+#!/usr/bin/awk -E
+
+function print_usage(){
+	print "Usage: ./awk_seed.awk [options]"
+	print "-h: Print this message."
+	print "-t: Specify type of seed."
+	exit 0
+}
+
+BEGIN {
+	type = "tomato"
+	for(i=1; i<ARGC; i++){
+		switch(ARGV[i]){
+		case "-t":
+			type = ARGV[++i]
+			break
+		case "-h":
+		default:
+			print_usage()
+		}
+	}
+	print "You planted a " type " seed!"
+}

--- a/seeds/awk_seed.awk
+++ b/seeds/awk_seed.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -E
+#!/usr/bin/gawk -E
 
 function print_usage(){
 	print "Usage: ./awk_seed.awk [options]"


### PR DESCRIPTION
After inspecting the [gawk manual](https://www.gnu.org/software/gawk/manual/html_node/ARGC-and-ARGV.html#ARGC-and-ARGV) I have come up with something like this.

The seed doesn't have a full fledged option parser, but the GNU manual has an [implementation of `getopt` in awk](https://www.gnu.org/software/gawk/manual/html_node/Getopt-Function.html#Getopt-Function) in case one needs complex option parsing in an awk script. 