### PR TITLE
Update Dockerfile to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,30 @@
-FROM ubuntu:18.04
-
+FROM ubuntu:20.04
 WORKDIR /root
+
+# set entrypoint and copy site stuff so that we can run the server in the docker container 
+ENTRYPOINT cd srv && python2 -m SimpleHTTPServer
+COPY style.css ./srv/
+COPY index.html ./srv/
+COPY main.js ./srv/
+COPY highlightjs/ ./srv/highlightjs
+COPY seeds ./srv/seeds
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get install -y curl gawk groovy nodejs openjdk-8-jre-headless php python ruby
+    apt-get install --no-install-recommends -y libicu-dev liblttng-ust0 wget gnupg2 curl gawk groovy nodejs openjdk-11-jre-headless php python ruby
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 # Install Scala from source.
-RUN curl -O https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.tgz && \
-    tar -C /opt -xzf scala-2.12.2.tgz && \
-    rm scala-2.12.2.tgz
-ENV SCALA_HOME=/opt/scala-2.12.2
+RUN curl -O https://downloads.lightbend.com/scala/2.13.3/scala-2.13.3.tgz && \
+    tar -C /opt -xzf scala-2.13.3.tgz && \
+    rm scala-2.13.3.tgz
+ENV SCALA_HOME=/opt/scala-2.13.3
 ENV PATH="${PATH}:${SCALA_HOME}/bin"
 
-# Install Powershell.
-RUN curl -O https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb && \
-    dpkg -i packages-microsoft-prod.deb && \
-    apt-get update && \
-    apt-get install -y powershell && \
-    rm packages-microsoft-prod.deb
+# Download Powershell binaries, as there is no Powershell package for 20.04 available yet
+RUN apt-get install --no-install-recommends -y libc6 libgcc1 libicu66 && \
+    curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v7.0.1/powershell-7.0.1-linux-x64.tar.gz && \
+    mkdir -p /opt/microsoft/powershell/7 && \
+    tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 && \
+    chmod +x /opt/microsoft/powershell/7/pwsh && \
+    ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh


### PR DESCRIPTION
Update Dockerfile:

- upgrade Ubuntu to 20.04
- add entry point to run server automatically from the docker container with "docker run --publish 8000:8000 -it scriptseed:latest" (should I update the documentation as well ?)

Note: Powershell is not available for Ubuntu 20.04 as a package, therefore prebuilt binaries are needed.