### PR TITLE
Add BASIC seed script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y\
     curl\
     erlang\
+    gambas3\
     gawk\
     gnupg2\
     golang\

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
                 <select id="langSelect">
                     <option value="bash">Bash</option>
                     <option value="awk">AWK</option>
+                    <option value="basic">BASIC (Gambas)</option>
                     <option value="deno">Deno</option>
                     <option value="erlang">Erlang</option>
                     <option value="golang">Go</option>

--- a/main.js
+++ b/main.js
@@ -8,6 +8,10 @@ const LANGUAGES = {
         file: 'seeds/bash_seed.sh',
         class: 'bash'
     },
+    'basic': {
+        file: 'seeds/basic_seed.bas',
+        class: 'basic'
+    },
     'deno': {
         file: 'seeds/deno_seed.js',
         class: 'deno'

--- a/seeds/basic_seed.bas
+++ b/seeds/basic_seed.bas
@@ -1,0 +1,25 @@
+#!/usr/bin/env gbs3
+
+' This is a BASIC script seed.
+' Use it as a template for your own BASIC (Gambas) script.
+
+IF ARGS[1] = "-h"
+    PRINT "Usage: ./bash_seed.sh [options]"
+    PRINT ""
+    PRINT "Prints a message as an example of parsing CLI args in BASIC/Gambas."
+    PRINT ""
+    PRINT "Options:"
+    PRINT "  -h       Prints this help message."
+    PRINT "  -n NAME  Specify the user's name."
+    QUIT
+END IF
+
+DIM name AS String
+name = "world"
+IF ARGS[1] = "-n" AND ARGS.Count > 2
+    name = ARGS[2]
+END IF
+
+PRINT "Hello " & name & "!"
+PRINT ""
+PRINT "You ran the BASIC (Gambas) seed script!"


### PR DESCRIPTION
This commit adds a BASIC seed script to our collection. It uses
[Gambas](http://gambas.sourceforge.net/en/main.html) as the interpreter.
Gambas is available in the apt repositories and can parse command line
arguments and run scripts with a shebang line.

* Add `seeds/basic_seed.bas`.
  * Prints a hello world message.
  * Prints a usage info when passed `-h`.
* Edit the Dockerfile to install Gambas.
* Add Basic to the dropdown in `index.html`.
* Add Basic to `main.js` for syntax highlighting.

Fixes #21