### PR TITLE
Update Dev Container to 22.04 Jammy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/ubuntu/.devcontainer/base.Dockerfile
 
-# [Choice] Ubuntu version: hirsute, bionic, focal
-ARG VARIANT="hirsute"
+# [Choice] Ubuntu version: bionic, focal, etc
+ARG VARIANT="jammy"
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
 ###
@@ -22,9 +22,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     gawk\
     gnupg2\
     golang\
-    julia\
     libicu-dev\
-    liblttng-ust0\
     lua5.3\
     liblua5.3-dev\
     luarocks\
@@ -32,7 +30,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     openjdk-11-jre-headless\
     php\
     powershell\
-    python\
+    python3\
     ruby\
     tcl\
     vim

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,8 @@
 	"name": "Script Seed",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
-		"args": { "VARIANT": "hirsute" }
+		// Update 'VARIANT' to pick an Ubuntu version: focal, bionic, etc
+		"args": { "VARIANT": "jammy" }
 	},
 
 	// Set *default* container specific settings.json values on container create.

--- a/seeds/python_seed.py
+++ b/seeds/python_seed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 
 # This is a Python script seed.


### PR DESCRIPTION
We were using Ubuntu 21.04 Hirsute for our dev container. This has been broken since Hirsute support ended in early 2022. Updating to the most recent LTS (22.04 Jammy) solves this problem.

* Change `python` to `python3`. There's no longer a binary at `/usr/bin/bython` by default.
* Remove a couple packages from our Dockerfile that aren't in the Jammy repos.

All tests are passing in the Docker environment after this upgrade!