### PR TITLE
Update devcontainer for 22.04

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
 # Microsoft GPG keys for PowerShell
 # https://docs.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7
-RUN wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb && \
+RUN wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \
     rm packages-microsoft-prod.deb
 


### PR DESCRIPTION
In 281b5bb856fe2829df97942a374fe05d89c3edb9, we updated our dev container to Ubuntu 22.04. I missed one instance of 20.04 in our Dockerfile -- this commit sets it to 22.04.