### PR TITLE
Upgrade Groovy to 4.0.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,10 +38,10 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 # Install Groovy binaries
 # Groovy is in the Ubuntu repos but version 3+ has bugfixes that get rid of warnings.
-RUN wget https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.9.zip && \
-    unzip apache-groovy-binary-3.0.9.zip -d /opt && \
-    rm apache-groovy-binary-3.0.9.zip
-ENV GROOVY_HOME="/opt/groovy-3.0.9"
+RUN wget https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-4.0.5.zip && \
+    unzip apache-groovy-binary-4.0.5.zip -d /opt && \
+    rm apache-groovy-binary-4.0.5.zip
+ENV GROOVY_HOME="/opt/groovy-4.0.5"
 ENV PATH="${PATH}:${GROOVY_HOME}/bin"
 
 # Install Scala from source.

--- a/seeds/groovy_seed.groovy
+++ b/seeds/groovy_seed.groovy
@@ -1,5 +1,7 @@
 #!/usr/bin/env groovy
 
+import groovy.cli.commons.CliBuilder
+
 // This is a Groovy script seed.
 // Use it as a template for your own Groovy script.
 


### PR DESCRIPTION
Upgrade Groovy to 4.0.5, which is the latest stable version from https://groovy.apache.org/download.html. Using 4.0.5 seems to require an import statement for `CliBuilder` that wasn't required in Groovy 3.