### PR TITLE
Use a unicode apostrophe in bash sample

### DIFF
--- a/seeds/bash_seed.sh
+++ b/seeds/bash_seed.sh
@@ -11,7 +11,7 @@ Prints a message as an example of parsing CLI args in Bash.
 
 Options:
   -h       Prints this help message.
-  -n NAME  Specify the user's name.
+  -n NAME  Specify the user’s name.
 
 EOF
 }


### PR DESCRIPTION
It looks a little nicer, but the primary advantage of doing this is that using a single quote `'` breaks hilightjs. Using a unicode apostrophe means the hilightjs will continue highlighting the rest of the file correctly.

Before:
![image](https://user-images.githubusercontent.com/12214617/193951712-65efb977-a30a-4be8-b515-e35d53417739.png)

After:
![image](https://user-images.githubusercontent.com/12214617/193951750-b2902122-8db1-4bd6-b819-41a5a53ea275.png)
