### PR TITLE
Update server for python 3

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -12,4 +12,4 @@ EOF
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "$SCRIPT_DIR/.."
-exec python2 -m SimpleHTTPServer
+exec python3 -m http.server


### PR DESCRIPTION
In https://github.com/mkasberg/script-seed/pull/76, we updated to Ubuntu 22.04 for our Docker container used for tests and serving the site locally. This update brought with it a change to python 3 as our default, and that broke our `bin/server` script since python 2 was no longer installed.

Update `bin/server` to use `python3`, which will be available in our Docker container.