### PR TITLE
Add getopts reference for bash

### DIFF
--- a/seeds/bash_seed.sh
+++ b/seeds/bash_seed.sh
@@ -19,6 +19,7 @@ EOF
 NAME=""
 HELP=false
 
+# See https://man7.org/linux/man-pages/man1/getopts.1p.html
 while getopts hn: opt; do
     case $opt in
         h)


### PR DESCRIPTION
Add a link to https://man7.org/linux/man-pages/man1/getopts.1p.html in the bash source code where `getopts` is used. This manpage is the most descriptive I was able to easily find online, and it includes an example of usage.