### PR TITLE
Hacky fix for PHP syntax highlighting

### DIFF
--- a/seeds/php_seed.php
+++ b/seeds/php_seed.php
@@ -11,7 +11,7 @@ Prints a message as an example of parsing CLI args in PHP.
 
 Options:
   -h|--help       Prints this help information.
-  -n|--name NAME  Specify the user's name.
+  -n|--name NAME  Specify the name of the user.
 
 EOD;
 


### PR DESCRIPTION
Prism.js has a bug that is preventing it from correctly highlighting our sample PHP code. The bug happens when the code includes a `<?php` tag and heredoc (`<<<END`) with a single quote (`'`) in it.

The website looks way better with working syntax highlighting, so let's work around this bug by removing the `'` from the heredoc in our PHP sample.

The bug has been reported to prism.js:
https://github.com/PrismJS/prism/issues/3571