### PR TITLE
Add EditorConfig

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,25 +1,25 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/ubuntu
 {
-	"name": "Script Seed",
-	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Ubuntu version: focal, bionic, etc
-		"args": { "VARIANT": "jammy" }
-	},
+  "name": "Script Seed",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick an Ubuntu version: focal, bionic, etc
+    "args": { "VARIANT": "jammy" }
+  },
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [],
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [8000],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [8000],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "uname -a",
 
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode"
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,38 @@
+# EditorConfig file: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# 2 space indentation on all seed scripts
+[seeds/*]
+indent_style = space
+indent_size = 2
+
+# 2 space indentation on non-seed code
+[*.{html,js,css,sh,json,yml}]
+indent_style = space
+indent_size = 2
+
+[bin/server]
+indent_style = space
+indent_size = 2
+
+[Dockerfile]
+indent_style = space
+indent_size = 4
+
+# Makefiles require tabs
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+# Don't check library files
+[/{prismjs,bootstrap}/**]
+indent_style = unset
+indent_size = unset

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,18 @@
 name: Script-Seed Actions
 on: [pull_request]
 jobs:
+
+  lint:
+    name: Lint (EditorConfig)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: snow-actions/eclint@v1.0.1
+        with:
+          args: check
+
   test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,12 @@ Thank you for contributing to Script Seed! Here are some notes to help you out.
 If you haven't finished the [README](README.md), start there to understand how
 this project uses VS Code Dev Containers and Docker.
 
+## EditorConfig
+
+We have a [EditorConfig](https://editorconfig.org/) file to enforce a consistent
+code style. It's recommended to use an appropriate EditorConfig plugin for your
+IDE. We enforce our code style with a check in GitHub Actions.
+
 ## Test Suite
 
 The test suite can be run with `test.sh` inside the dev container:

--- a/main.js
+++ b/main.js
@@ -32,11 +32,11 @@ const LANGUAGES = {
         file: 'seeds/javascript_seed.js',
         class: 'language-js'
     },
-	'julia': {
+  'julia': {
         file: 'seeds/julia_seed.jl',
         class: 'language-julia'
     },
-	'lua': {
+  'lua': {
         file: 'seeds/lua_seed.lua',
         class: 'language-lua'
     },
@@ -64,7 +64,7 @@ const LANGUAGES = {
         file: 'seeds/scala_seed.scala',
         class: 'language-scala'
     },
-	'tcl': {
+  'tcl': {
         file: 'seeds/tcl_seed.tcl',
         class: 'language-tcl'
     }

--- a/seeds/awk_seed.awk
+++ b/seeds/awk_seed.awk
@@ -4,30 +4,30 @@
 # Use it as a template for your own Awk script.
 
 function print_usage(){
-	print "Usage: ./awk_seed.awk [options]"
-	print ""
-	print "Prints a message as an example of parsing CLI args in Awk."
-	print ""
-	print "Options:"
-	print "  -h       Print this message."
-	print "  -n NAME  Specify the user's name."
-	exit 0
+  print "Usage: ./awk_seed.awk [options]"
+  print ""
+  print "Prints a message as an example of parsing CLI args in Awk."
+  print ""
+  print "Options:"
+  print "  -h       Print this message."
+  print "  -n NAME  Specify the user's name."
+  exit 0
 }
 
 BEGIN {
-	name = "world"
-	for(i=1; i<ARGC; i++){
-		switch(ARGV[i]){
-		case "-n":
-			name = ARGV[++i]
-			break
-		case "-h":
-		default:
-			print_usage()
-		}
-	}
+  name = "world"
+  for(i=1; i<ARGC; i++){
+    switch(ARGV[i]){
+    case "-n":
+      name = ARGV[++i]
+      break
+    case "-h":
+    default:
+      print_usage()
+    }
+  }
 
-	print "Hello " name "!"
-	print ""
-	print "You ran the Awk seed script!"
+  print "Hello " name "!"
+  print ""
+  print "You ran the Awk seed script!"
 }

--- a/seeds/go_seed.go
+++ b/seeds/go_seed.go
@@ -1,25 +1,25 @@
 //usr/bin/env go run "$0" "$@"; exit "$?"
 package main
 import (
-	"flag"
-	"fmt"
-	"os"
+  "flag"
+  "fmt"
+  "os"
 )
 
 // This is a Go script seed.
 // Use it as a template for your own Go script.
 
 func main() {
-	name := flag.String("n", "world", "Specify the user's name.")
-	
-	// See https://pkg.go.dev/flag
-	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "usage: %s [options]\n\nPrints a message as an example of parsing CLI args in Go.\n\nOptions:\n", os.Args[0])
+  name := flag.String("n", "world", "Specify the user's name.")
 
-		flag.PrintDefaults()
-	}
-	
-	flag.Parse()
+  // See https://pkg.go.dev/flag
+  flag.Usage = func() {
+    fmt.Fprintf(os.Stderr, "usage: %s [options]\n\nPrints a message as an example of parsing CLI args in Go.\n\nOptions:\n", os.Args[0])
 
-	fmt.Printf("Hello %s!\n\nYou ran the Go seed script!\n", *name)
+    flag.PrintDefaults()
+  }
+
+  flag.Parse()
+
+  fmt.Printf("Hello %s!\n\nYou ran the Go seed script!\n", *name)
 }

--- a/seeds/perl_seed.pl
+++ b/seeds/perl_seed.pl
@@ -9,8 +9,9 @@ use Pod::Usage;
 
 my $help = 0;
 my $name = 'world';
-GetOptions('help|h' => \$help,
-           'name|n=s' => \$name
+GetOptions(
+  'help|h' => \$help,
+  'name|n=s' => \$name
 );
 pod2usage(0) if $help;
 

--- a/seeds/scala_seed.scala
+++ b/seeds/scala_seed.scala
@@ -5,11 +5,11 @@
 
 object ScalaSeed {
   val usage = """Prints a message as an example of parsing CLI args in Scala.
-                |Usage: scala_seed.scala [options]
-                |
-                |Options:
-                |  -h \tDisplay help.
-                |  -n \tSpecify the user's name.""".stripMargin
+    |Usage: scala_seed.scala [options]
+    |
+    |Options:
+    |  -h \tDisplay help.
+    |  -n \tSpecify the user's name.""".stripMargin
 
   def main(args: Array[String]) = {
     if (args.length == 0) {
@@ -25,8 +25,8 @@ object ScalaSeed {
 
   def printMessage(name: String) = {
     val message = s"""Hello $name!
-                     |
-                     |You ran the Scala seed script!""".stripMargin
+      |
+      |You ran the Scala seed script!""".stripMargin
     println(message)
   }
 }

--- a/style.css
+++ b/style.css
@@ -72,18 +72,18 @@ footer {
     border-radius: 15px;
     animation: toastIt 3000ms cubic-bezier(0.785, 0.135, 0.15, 0.86) forwards;
   }
-  
+
   .toastContainer p {
     padding: 0;
     margin: 0;
   }
-  
+
   .toastContainer_message {
     font-size: 0.5rem;
     font-weight: bold;
     line-height: 1;
   }
-  
+
   @keyframes toastIt {
     0%,
     100% {


### PR DESCRIPTION
It would be great to use a code formatter/linter to ensure consistency
within this repo and across all of our seed scripts. But it's
challenging because we want to format code consistently in 15+
languages. [EditorConfig](https://editorconfig.org/) seems like a good
place to start since it's widely used and language-agnostic. We can use
`eclint` in GitHub Actions to enforce code style.

* Use consistent line endings everywhere.
* Use 2-space indent on most files. Enforce this by file type (for
  non-seed code) and for anything in the `seeds/` dir (since we don't
  know file types that might be added in the future).
* Ensure we don't reformat packaged libraries (bootstrap/prismjs).